### PR TITLE
Update Gaussholder to 1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"humanmade/tachyon-plugin": "^0.9.2",
 		"humanmade/smart-media": "^0.1.11",
-		"humanmade/gaussholder": "^1.0.0",
+		"humanmade/gaussholder": "1.1.0",
 		"humanmade/aws-rekognition": "^0.1.2"
 	},
 	"autoload" : {


### PR DESCRIPTION
This includes compat fixes with Tachyon and S3-Uploads.