### PR TITLE
Fix compatibility with Tachyon and Gaussholder

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -38,6 +38,9 @@ function load_plugins() {
 			add_filter( 'gaussholder.image_sizes', __NAMESPACE__ . '\\set_gaussholder_image_sizes' );
 		}
 		require_once $vendor_dir . '/humanmade/gaussholder/gaussholder.php';
+		if ( $config['tachyon'] ) {
+			add_action( 'plugins_loaded', __NAMESPACE__ . '\\set_gaussholder_filter_after_tachyon', 11 );
+		}
 	}
 
 	if ( $config['rekognition'] ) {
@@ -62,6 +65,22 @@ function set_gaussholder_image_sizes( array $sizes ) : array {
 	$config = Platform\get_config()['modules']['media'];
 	$sizes = array_merge( $sizes, $config['gaussholder']['image-sizes'] );
 	return $sizes;
+}
+
+/**
+ * Re-order the Gaussholder content filter after Tachyon.
+ *
+ * Because Gaussholder and Tachyon filter the post content via the
+ * the_content filter, we need to make sure it happens in the correct
+ * order, as we want Gaussholder to hook in after Tachyon has done
+ * all the image URL replacements.
+ *
+ * @return void
+ */
+function set_gaussholder_filter_after_tachyon() {
+	remove_filter( 'the_content', 'Gaussholder\\Frontend\\mangle_images', 30 );
+	// Tachyon hooks the content at 999999.
+	add_filter( 'the_content', 'Gaussholder\\Frontend\\mangle_images', 999999 + 1 );
 }
 
 /**


### PR DESCRIPTION
Currently Gaussholder is doing it's thing on `the_content` before Tachyon (Tachyon has a horribly high hook), which means images URLs don't correctly match. We need the image URLs in the post content to exactly match the urls returned by `get_attachment_image_src` et al, because that's how Gaussholder works out what `size` an image is (per https://github.com/humanmade/Gaussholder/pull/37)