### PR TITLE
Update gaussholder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"humanmade/tachyon-plugin": "0.10.1",
 		"humanmade/smart-media": "0.1.13",
-		"humanmade/gaussholder": "1.1.2",
+		"humanmade/gaussholder": "1.1.3",
 		"humanmade/aws-rekognition": "^0.1.2"
 	},
 	"autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"humanmade/tachyon-plugin": "0.10.1",
 		"humanmade/smart-media": "0.1.13",
-		"humanmade/gaussholder": "1.1.1",
+		"humanmade/gaussholder": "1.1.2",
 		"humanmade/aws-rekognition": "^0.1.2"
 	},
 	"autoload" : {


### PR DESCRIPTION
Changelog:

v1.2.3
- Fixes the SVG clip path displaying when images displayed inline #40 

v1.1.2
- Fix image sizes on non-cropped images [#39](https://github.com/humanmade/Gaussholder/pull/39)